### PR TITLE
Fixed - adição de rótulo de legenda para acessibilidade

### DIFF
--- a/ControleEstoque.Web/ControleEstoque.Web/Views/OperEntradaProduto/Index.cshtml
+++ b/ControleEstoque.Web/ControleEstoque.Web/Views/OperEntradaProduto/Index.cshtml
@@ -13,6 +13,7 @@
             <hr />
             <div id="msg_mensagem_aviso" class="text-danger invisivel"></div>
             <fieldset>
+                <legend>Handler Product</legend>
                 @Html.AntiForgeryToken()
                 <div class="row">
                     <div class="col-md-6">


### PR DESCRIPTION
Para usuários de tecnologia assistiva, como leitores de tela, pode ser um desafio saber o que é esperado na entrada de cada formulário. O rótulo da entrada por si só pode não ser suficiente: 'rua' pode fazer parte de um endereço de cobrança ou de entrega, por exemplo.